### PR TITLE
Enhance CLI argument parsing and add max file lines option for context splitting

### DIFF
--- a/repo_context/cli.py
+++ b/repo_context/cli.py
@@ -22,8 +22,8 @@ def parse_args() -> Namespace:
         "--output",
         "-o",
         type=str,
-        default="context.md",
-        help="Output file path",
+        default=".",
+        help="Output directory",
     )
     parser.add_argument(
         "--ignore",
@@ -35,6 +35,12 @@ def parse_args() -> Namespace:
         "--ignore-file",
         type=str,
         help="File containing ignore patterns (one per line)",
+    )
+    parser.add_argument(
+        "--max-file-lines",
+        type=int,
+        default=None,
+        help="Maximum number of lines in context files",
     )
     args = parser.parse_args()
     return args
@@ -60,11 +66,12 @@ def main():
         else:
             repo_path = Path(args.source)
 
-        context = converter.convert(repo_path)
+        context = converter.convert(repo_path, max_file_lines=args.max_file_lines)
 
-        output_path = Path(args.output)
-        output_path.write_text(context)
-        logger.info(f"Context written to {output_path}")
+        for i, c in enumerate(context):
+            output_path = Path(f"{args.output}/context_{i}.md")
+            output_path.write_text(c)
+            logger.info(f"Context written to {output_path}")
 
     except Exception as e:
         logger.error(f"Error: {e}")

--- a/tests/test_repo_converter.py
+++ b/tests/test_repo_converter.py
@@ -85,7 +85,7 @@ def test_process_file(converter, temp_repo):
 
 
 def test_convert(converter, temp_repo):
-    result = converter.convert(temp_repo)
+    result = converter.convert(temp_repo)[0]
     assert "file.txt" in result
     assert "test content" in result
     assert "empty.txt" not in result
@@ -96,3 +96,98 @@ def test_convert(converter, temp_repo):
 def test_convert_nonexistent_path(converter):
     with pytest.raises(FileNotFoundError):
         converter.convert(Path("nonexistent"))
+
+
+def test_empty_context(converter):
+    result = converter._split_context([], 100)
+    assert result == []
+
+
+def test_single_chunk(converter):
+    context = [
+        "# File: test1.py\n```\nprint('hello')\n```\n",
+        "# File: test2.py\n```\nprint('world')\n```\n",
+    ]
+    result = converter._split_context(context, 10)
+    assert len(result) == 1
+    assert result[0] == "\n".join(context)
+
+
+def test_multiple_chunks(converter):
+    context = [
+        "# File: test1.py\n```\nline1\nline2\n```\n",  # 4 lines
+        "# File: test2.py\n```\nline1\nline2\n```\n",  # 4 lines
+        "# File: test3.py\n```\nline1\nline2\nline3\n```\n",  # 6 lines
+    ]
+    result = converter._split_context(context, 10)
+    assert len(result) == 2
+    # First chunk should contain first and second files (8 lines total)
+    assert result[0] == "\n".join([context[0], context[1]])
+    # Second chunk should contain third file (6 lines)
+    assert result[1] == context[2]
+
+
+def test_exact_chunk_size(converter):
+    context = [
+        "# File: test1.py\n```\nline1\n```\n",  # 4 lines
+        "# File: test2.py\n```\nline1\n```\n",  # 4 lines
+    ]
+    result = converter._split_context(context, 4)
+    assert len(result) == 2
+    assert result[0] == context[0]
+    assert result[1] == context[1]
+
+
+def test_large_single_file(converter):
+    large_file = "# File: large.py\n```\n" + "line\n" * 10 + "```\n"
+    result = converter._split_context([large_file], 5)
+    assert len(result) == 1
+    assert result[0] == large_file
+
+
+def test_mixed_file_sizes(converter):
+    context = [
+        "# File: small1.py\n```\nline1\n```\n",  # 4 lines
+        "# File: large.py\n```\n" + "line\n" * 8 + "```\n",  # 11 lines
+        "# File: small2.py\n```\nline1\n```\n",  # 4 lines
+    ]
+    result = converter._split_context(context, 6)
+    assert len(result) == 3
+    assert result[0] == context[0]
+    assert result[1] == context[1]
+    assert result[2] == context[2]
+
+
+def test_zero_max_lines(converter):
+    context = ["# File: test.py\n```\nline1\n```\n"]
+    with pytest.raises(ValueError):
+        converter._split_context(context, 0)
+
+
+def test_negative_max_lines(converter):
+    context = ["# File: test.py\n```\nline1\n```\n"]
+    with pytest.raises(ValueError):
+        converter._split_context(context, -5)
+
+
+def test_newline_counting(converter):
+    context = [
+        "# File: test1.py\n```\nline1\r\nline2\rline3\n```\n",  # Mixed newlines
+        "# File: test2.py\n```\nline1\nline2\n```\n",  # Unix newlines
+    ]
+    result = converter._split_context(context, 5)
+    assert len(result) == 2
+    assert result[0] == context[0]
+    assert result[1] == context[1]
+
+
+def test_preserve_file_boundaries(converter):
+    context = [
+        "# File: test1.py\n```\nline1\nline2\n```\n",  # 5 lines
+        "# File: test2.py\n```\nline1\nline2\n```\n",  # 5 lines
+        "# File: test3.py\n```\nline1\nline2\n```\n",  # 5 lines
+    ]
+    result = converter._split_context(context, 7)
+    assert len(result) == 3
+    # Each file should be in its own chunk
+    assert all(chunk == original for chunk, original in zip(result, context))


### PR DESCRIPTION
This pull request introduces several changes to the `repo_context` module, primarily focusing on adding functionality to split context files based on a maximum number of lines and updating related tests. The most important changes include modifying the `convert` method to support splitting context files, updating the CLI to accept a new argument for the maximum number of lines, and adding comprehensive tests for the new functionality.

### Changes to `repo_context/cli.py`:
* Modified the `--output` argument to specify an output directory instead of a file path.
* Added a new argument `--max-file-lines` to specify the maximum number of lines in context files.
* Updated the `main` function to handle multiple context files and write each to a separate file.

### Changes to `repo_context/repo_converter.py`:
* Updated the `convert` method to support splitting context files based on the maximum number of lines. [[1]](diffhunk://#diff-f4a7c99b950f30b2da4ada10986a88391ac9a0a85e62d88146f028d9b911f6b6L135-R144) [[2]](diffhunk://#diff-f4a7c99b950f30b2da4ada10986a88391ac9a0a85e62d88146f028d9b911f6b6L172-R179)
* Added a new method `_split_context` to handle the logic for splitting context files.

### Changes to `tests/test_repo_converter.py`:
* Updated existing tests to accommodate the changes in the `convert` method.
* Added new tests to verify the functionality of the `_split_context` method, including edge cases and error handling.