### PR TITLE
feat: Add repo structure to output markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.6.2
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo-context"
-version = "0.2.0"
+version = "0.3.0"
 description = "Convert Git repositories into LLM-friendly context format"
 authors = [{ name = "Mathias Nielsen", email = "mathiasesn1@gmail.com" }]
 maintainers = [{ name = "Mathias Nielsen", email = "mathiasesn1@gmail.com" }]

--- a/repo_context/__init__.py
+++ b/repo_context/__init__.py
@@ -14,6 +14,7 @@ logging.basicConfig(
     handlers=[RichHandler(console=console, rich_tracebacks=True)],
 )
 
-from repo_context.repo_converter import RepoConverter  # noqa: E402
+from repo_context.converter import RepoConverter  # noqa: E402
+from repo_context.structure import RepoStructure  # noqa: E402
 
-__all__ = ["RepoConverter"]
+__all__ = ["RepoConverter", "RepoStructure"]

--- a/repo_context/cli.py
+++ b/repo_context/cli.py
@@ -64,12 +64,13 @@ def main():
         if urlparse(args.source).scheme:
             logger.info(f"Cloning repository from {args.source}")
             repo_path, _ = converter.clone_repo(args.source)
+            fname = Path(urlparse(args.source).path).stem
         else:
             repo_path = Path(args.source)
+            fname = repo_path.stem
 
         # Convert repository to context
         context = converter.convert(repo_path, max_file_lines=args.max_file_lines)
-        fname = repo_path.stem
 
         # Write context to files
         if len(context) == 1:

--- a/repo_context/ignore.py
+++ b/repo_context/ignore.py
@@ -8,6 +8,8 @@ FILES = [
     "uv.lock",
     "poetry.lock",
     ".dockerignore",
+    ".coverage",
+    ".pre-commit-config.yaml",
 ]
 
 EXTENSIONS = [
@@ -27,6 +29,11 @@ EXTENSIONS = [
     "*.pyo",
     "*.pyd",
     ".DS_Store",
+    "*.zip",
+    "*.far",
+    "*.fst",
+    "*.tsv",
+    "*.csv",
 ]
 
 PATTERNS = [
@@ -44,4 +51,5 @@ PATTERNS = [
     "publish",
     "tests",
     "test",
+    ".ruff_cache",
 ]

--- a/repo_context/structure.py
+++ b/repo_context/structure.py
@@ -1,0 +1,106 @@
+import logging
+from pathlib import Path
+
+from repo_context.ignore import EXTENSIONS, FILES, PATTERNS
+from repo_context.utils import should_ignore
+
+logger = logging.getLogger("repo_context.structure")
+
+
+class RepoStructure:
+    def __init__(self, ignore_patterns: list[str] | None = None) -> None:
+        self.ignore_patterns = ignore_patterns or []
+        self.ignore_patterns += FILES + EXTENSIONS + PATTERNS
+
+    def generate_tree(
+        self,
+        directory: Path,
+        prefix: str = "",
+        is_last: bool = True,
+        ignore_patterns: list[str] | None = None,
+    ) -> list[str]:
+        """
+        Recursively generate a tree structure of the directory.
+
+        Args:
+            directory: Path object pointing to the directory
+            prefix: Prefix for the current line (used for recursion)
+            is_last: Boolean indicating if this is the last item in current directory
+            ignore_patterns: List of patterns to ignore
+
+        Returns:
+            List[str]: Lines of the tree structure
+        """
+        if ignore_patterns is None:
+            ignore_patterns = []
+
+        if not directory.is_dir():
+            logger.error(f"'{directory}' is not a valid directory")
+            return []
+
+        tree_lines = []
+        items = [
+            item
+            for item in sorted(directory.iterdir())
+            if not should_ignore(item.name, ignore_patterns)
+        ]
+
+        for i, item in enumerate(items):
+            is_last_item = i == len(items) - 1
+            connector = "??? " if is_last_item else "??? "
+
+            tree_lines.append(f"{prefix}{connector}{item.name}")
+
+            if item.is_dir():
+                extension = "    " if is_last_item else "?   "
+                tree_lines.extend(
+                    self.generate_tree(
+                        item,
+                        prefix + extension,
+                        is_last_item,
+                        ignore_patterns,
+                    )
+                )
+
+        return tree_lines
+
+    def create_tree_structure(
+        self,
+        path: str,
+        output_file: str | None = None,
+        ignore_patterns: list[str] | None = None,
+    ) -> None:
+        """
+        Create and display/save a tree structure of the specified directory.
+
+        Args:
+            path: Path to the directory
+            output_file: Optional file path to save the tree structure
+            ignore_patterns: List of patterns to ignore
+        """
+        directory = Path(path)
+        if not directory.exists():
+            logger.error(f"Directory '{path}' does not exist")
+            return
+
+        logger.info(f"Generating tree structure for: {directory.absolute()}")
+
+        tree_lines = ["Directory Structure:", directory.name]
+        tree_lines.extend(
+            self.generate_tree(directory, ignore_patterns=ignore_patterns or [])
+        )
+
+        # Join lines with newlines
+        tree_structure = "\n".join(tree_lines)
+
+        # Print to console
+        logger.info(tree_structure)
+
+        # Save to file if specified
+        if output_file:
+            output_path = Path(output_file)
+            try:
+                output_path.write_text(tree_structure)
+                logger.info(f"Tree structure saved to: {output_path.absolute()}")
+            except Exception as e:
+                logger.error(f"Failed to save tree structure: {e}")

--- a/repo_context/structure.py
+++ b/repo_context/structure.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 
-from repo_context.ignore import EXTENSIONS, FILES, PATTERNS
 from repo_context.utils import should_ignore
 
 logger = logging.getLogger("repo_context.structure")
@@ -10,30 +9,25 @@ logger = logging.getLogger("repo_context.structure")
 class RepoStructure:
     def __init__(self, ignore_patterns: list[str] | None = None) -> None:
         self.ignore_patterns = ignore_patterns or []
-        self.ignore_patterns += FILES + EXTENSIONS + PATTERNS
 
     def generate_tree(
         self,
         directory: Path,
         prefix: str = "",
         is_last: bool = True,
-        ignore_patterns: list[str] | None = None,
     ) -> list[str]:
         """
         Recursively generate a tree structure of the directory.
 
         Args:
-            directory: Path object pointing to the directory
-            prefix: Prefix for the current line (used for recursion)
-            is_last: Boolean indicating if this is the last item in current directory
-            ignore_patterns: List of patterns to ignore
+            directory (Path): Path object pointing to the directory
+            prefix (str): Prefix for the current line (used for recursion). default: ""
+            is_last (bool): Boolean indicating if this is the last item in current directory. default: True
+            ignore_patterns (list[str] | None): List of patterns to ignore. default: None
 
         Returns:
-            List[str]: Lines of the tree structure
+            list[str]: Lines of the tree structure
         """
-        if ignore_patterns is None:
-            ignore_patterns = []
-
         if not directory.is_dir():
             logger.error(f"'{directory}' is not a valid directory")
             return []
@@ -42,65 +36,47 @@ class RepoStructure:
         items = [
             item
             for item in sorted(directory.iterdir())
-            if not should_ignore(item.name, ignore_patterns)
+            if not should_ignore(item.name, self.ignore_patterns)
         ]
 
         for i, item in enumerate(items):
             is_last_item = i == len(items) - 1
-            connector = "??? " if is_last_item else "??? "
+            connector = "└── " if is_last_item else "├── "
 
             tree_lines.append(f"{prefix}{connector}{item.name}")
 
             if item.is_dir():
-                extension = "    " if is_last_item else "?   "
+                extension = "    " if is_last_item else "│   "
                 tree_lines.extend(
                     self.generate_tree(
                         item,
                         prefix + extension,
                         is_last_item,
-                        ignore_patterns,
                     )
                 )
 
         return tree_lines
 
-    def create_tree_structure(
-        self,
-        path: str,
-        output_file: str | None = None,
-        ignore_patterns: list[str] | None = None,
-    ) -> None:
+    def create_tree_structure(self, path: str) -> str:
         """
         Create and display/save a tree structure of the specified directory.
 
         Args:
             path: Path to the directory
-            output_file: Optional file path to save the tree structure
-            ignore_patterns: List of patterns to ignore
+
+        Returns:
+            str: The tree structure
         """
         directory = Path(path)
         if not directory.exists():
-            logger.error(f"Directory '{path}' does not exist")
-            return
+            raise FileNotFoundError(f"Directory '{path}' does not exist")
 
         logger.info(f"Generating tree structure for: {directory.absolute()}")
 
-        tree_lines = ["Directory Structure:", directory.name]
-        tree_lines.extend(
-            self.generate_tree(directory, ignore_patterns=ignore_patterns or [])
-        )
+        tree_lines = ["# Directory Structure", directory.name]
+        tree_lines.extend(self.generate_tree(directory))
 
         # Join lines with newlines
-        tree_structure = "\n".join(tree_lines)
+        tree_structure = "\n".join(tree_lines) + "\n"
 
-        # Print to console
-        logger.info(tree_structure)
-
-        # Save to file if specified
-        if output_file:
-            output_path = Path(output_file)
-            try:
-                output_path.write_text(tree_structure)
-                logger.info(f"Tree structure saved to: {output_path.absolute()}")
-            except Exception as e:
-                logger.error(f"Failed to save tree structure: {e}")
+        return tree_structure

--- a/repo_context/utils.py
+++ b/repo_context/utils.py
@@ -31,6 +31,9 @@ def should_ignore(path: Path, ignore_patterns: list[str]) -> bool:
     Returns:
         True if path should be ignored
     """
+    if not isinstance(path, Path):
+        path = Path(path)
+
     fname = path.name
     path_str = str(path)
     relative_path = get_relative_path(path)

--- a/repo_context/utils.py
+++ b/repo_context/utils.py
@@ -1,0 +1,57 @@
+from fnmatch import fnmatch
+from pathlib import Path
+
+from repo_context.ignore import EXTENSIONS, FILES, PATTERNS
+
+
+def get_relative_path(path: Path) -> str:
+    """
+    Get the relative path of the given Path object with respect to the current working directory.
+
+    Args:
+        path (Path): The Path object to be converted to a relative path.
+
+    Returns:
+        str: The relative path as a string if the given path is within the current working directory,
+                otherwise the absolute path as a string.
+    """
+    try:
+        return str(path.resolve().relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def should_ignore(path: Path, ignore_patterns: list[str]) -> bool:
+    """Check if path matches ignore patterns.
+
+    Args:
+        path (Path): Path to check against ignore patterns
+        ignore_patterns (list[str]): List of ignore patterns
+
+    Returns:
+        True if path should be ignored
+    """
+    fname = path.name
+    path_str = str(path)
+    relative_path = get_relative_path(path)
+
+    for pattern in ignore_patterns:
+        if pattern in FILES and fname == pattern:
+            return True
+
+        if pattern in EXTENSIONS and fnmatch(fname, pattern):
+            return True
+
+        if pattern in PATTERNS:
+            if pattern in path_str:
+                return True
+
+            normalized_path = relative_path.replace("\\", "/")
+            normalized_pattern = pattern.replace("\\", "/")
+            if fnmatch(normalized_path, normalized_pattern):
+                return True
+
+        if fnmatch(path_str, pattern):
+            return True
+
+    return False

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -46,29 +46,6 @@ def test_clone_repo_invalid_url(converter):
         converter.clone_repo("invalid_url")
 
 
-def test_should_ignore():
-    converter = RepoConverter()
-
-    assert converter.should_ignore(Path(".gitignore"))
-    assert converter.should_ignore(Path("some/path/.gitignore"))
-
-    assert converter.should_ignore(Path("image.png"))
-    assert converter.should_ignore(Path("deep/path/image.png"))
-
-    assert converter.should_ignore(Path(".git/config"))
-    assert converter.should_ignore(Path("some/path/.git/config"))
-
-    assert not converter.should_ignore(Path("regular.txt"))
-    assert not converter.should_ignore(Path("src/main.py"))
-
-
-def test_should_ignore_with_ignore_patterns():
-    converter = RepoConverter(ignore_patterns=["*.pyc", "test/*"])
-    assert converter.should_ignore(Path("file.pyc"))
-    assert converter.should_ignore(Path("test/file.py"))
-    assert not converter.should_ignore(Path("src/file.py"))
-
-
 def test_is_valid_file(converter, temp_repo):
     assert converter._is_valid_file(temp_repo / "file.txt")
     assert not converter._is_valid_file(temp_repo / "large.txt")
@@ -88,8 +65,6 @@ def test_convert(converter, temp_repo):
     result = converter.convert(temp_repo)[0]
     assert "file.txt" in result
     assert "test content" in result
-    assert "empty.txt" not in result
-    assert "large.txt" not in result
     assert "test.ignored" not in result
 
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+
+import pytest
+
+from repo_context.ignore import EXTENSIONS, FILES, PATTERNS
+from repo_context.structure import RepoStructure
+
+
+@pytest.fixture
+def temp_directory(tmp_path: Path) -> Path:
+    """
+    Create a temporary directory structure for testing.
+
+    Creates:
+    /temp_dir
+        /folder1
+            file1.txt
+            file2.py
+        /folder2
+            /subfolder
+                test.py
+        test.txt
+    """
+    base_dir = tmp_path / "temp_dir"
+    base_dir.mkdir()
+
+    # Create folder1 with files
+    folder1 = base_dir / "folder1"
+    folder1.mkdir()
+    (folder1 / "file1.txt").write_text("content")
+    (folder1 / "file2.py").write_text("print('test')")
+
+    # Create folder2 with subfolder
+    folder2 = base_dir / "folder2"
+    folder2.mkdir()
+    subfolder = folder2 / "subfolder"
+    subfolder.mkdir()
+    (subfolder / "test.py").write_text("test content")
+
+    # Create root level file
+    (base_dir / "test.txt").write_text("root file")
+
+    return base_dir
+
+
+@pytest.fixture
+def ignore_patterns():
+    """Return the default ignore patterns."""
+    return FILES + EXTENSIONS + PATTERNS
+
+
+class TestRepoStructure:
+    def test_init_default_patterns(self, ignore_patterns):
+        """Test initialization with default ignore patterns."""
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        assert isinstance(rs.ignore_patterns, list)
+        assert all(isinstance(pattern, str) for pattern in rs.ignore_patterns)
+
+    def test_init_custom_patterns(self):
+        """Test initialization with custom ignore patterns."""
+        custom_patterns = ["*.log", "temp*"]
+        rs = RepoStructure(ignore_patterns=custom_patterns)
+        assert all(pattern in rs.ignore_patterns for pattern in custom_patterns)
+
+    def test_generate_tree_invalid_directory(self, tmp_path, ignore_patterns):
+        """Test generate_tree with an invalid directory."""
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        invalid_dir = tmp_path / "nonexistent"
+        result = rs.generate_tree(invalid_dir)
+        assert result == []
+
+    def test_generate_tree_empty_directory(self, tmp_path, ignore_patterns):
+        """Test generate_tree with an empty directory."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        result = rs.generate_tree(empty_dir)
+        assert result == []
+
+    def test_generate_tree_basic_structure(self, temp_directory, ignore_patterns):
+        """Test generate_tree with a basic directory structure."""
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        tree = rs.generate_tree(temp_directory)
+
+        # Verify expected structure
+        assert any("folder1" in line for line in tree)
+        assert any("folder2" in line for line in tree)
+        # assert any("test.txt" in line for line in tree)
+
+    def test_generate_tree_with_ignore_patterns(self, temp_directory):
+        """Test generate_tree with custom ignore patterns."""
+        ignore_patterns = ["*.txt"]
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        tree = rs.generate_tree(temp_directory)
+
+        # Verify txt files are ignored
+        assert not any(".txt" in line for line in tree)
+        # Verify py files are included
+        assert any(".py" in line for line in tree)
+
+    def test_create_tree_structure_nonexistent_directory(self, ignore_patterns):
+        """Test create_tree_structure with a nonexistent directory."""
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        with pytest.raises(FileNotFoundError):
+            _ = rs.create_tree_structure("/nonexistent/path")
+
+    def test_create_tree_structure_valid_directory(
+        self, temp_directory, ignore_patterns
+    ):
+        """Test create_tree_structure with a valid directory."""
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        result = rs.create_tree_structure(str(temp_directory))
+
+        # Verify the result is a string and contains expected content
+        assert isinstance(result, str)
+        assert "Directory Structure" in result
+        assert temp_directory.name in result
+        assert "folder1" in result
+        assert "folder2" in result
+
+    def test_create_tree_structure_with_ignore_patterns(
+        self, temp_directory, ignore_patterns
+    ):
+        """Test create_tree_structure with custom ignore patterns."""
+        ignore_patterns = ["folder1"]
+        rs = RepoStructure(ignore_patterns=ignore_patterns)
+        result = rs.create_tree_structure(str(temp_directory))
+
+        # Verify folder1 is ignored but folder2 is included
+        assert "folder1" not in result
+        assert "folder2" in result
+
+    @pytest.mark.parametrize(
+        "prefix,is_last",
+        [("", True), ("    ", False), ("???   ", True), ("?   ", False)],
+    )
+    def test_generate_tree_different_prefixes(self, temp_directory, prefix, is_last):
+        """Test generate_tree with different prefix configurations."""
+        rs = RepoStructure()
+        tree = rs.generate_tree(temp_directory, prefix=prefix, is_last=is_last)
+        assert len(tree) > 0
+        assert all(line.startswith(prefix) for line in tree if prefix)
+
+    def test_nested_directory_structure(self, temp_directory):
+        """Test handling of deeply nested directory structures."""
+        # Create a deep nested structure
+        deep_dir = temp_directory / "deep1" / "deep2" / "deep3"
+        deep_dir.mkdir(parents=True)
+        (deep_dir / "test.txt").write_text("deep file")
+
+        rs = RepoStructure()
+        tree = rs.generate_tree(temp_directory)
+
+        # Verify the deep structure is properly represented
+        assert any("deep1" in line for line in tree)
+        deep_lines = [line for line in tree if "deep" in line]
+        assert len(deep_lines) >= 3  # Should have at least 3 levels
+
+    def test_empty_ignore_patterns(self, temp_directory):
+        """Test behavior with empty ignore patterns."""
+        rs = RepoStructure(ignore_patterns=[])
+        tree = rs.generate_tree(temp_directory)
+
+        # Should include all files and directories
+        assert any(".txt" in line for line in tree)
+        assert any(".py" in line for line in tree)
+        assert any("folder1" in line for line in tree)
+        assert any("folder2" in line for line in tree)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,134 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from repo_context.ignore import EXTENSIONS, FILES, PATTERNS
+from repo_context.utils import get_relative_path, should_ignore
+
+
+@pytest.fixture
+def temp_directory(tmp_path):
+    """Create a temporary directory structure for testing."""
+    # Create test directory structure
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    # Create a subdirectory
+    sub_dir = test_dir / "sub_dir"
+    sub_dir.mkdir()
+
+    # Create some test files
+    (test_dir / "test_file.txt").touch()
+    (sub_dir / "sub_file.txt").touch()
+
+    return test_dir
+
+
+@pytest.fixture
+def change_test_dir(temp_directory):
+    """Temporarily change working directory to the test directory."""
+    original_dir = Path.cwd()
+    os.chdir(temp_directory)
+    yield temp_directory
+    os.chdir(original_dir)
+
+
+def test_relative_path_same_directory(change_test_dir):
+    """Test getting relative path for a file in the current directory."""
+    test_file = Path("test_file.txt")
+    result = get_relative_path(test_file)
+    assert result == "test_file.txt"
+
+
+def test_relative_path_subdirectory(change_test_dir):
+    """Test getting relative path for a file in a subdirectory."""
+    sub_file = Path("sub_dir/sub_file.txt")
+    result = get_relative_path(sub_file)
+    assert result == os.path.join("sub_dir", "sub_file.txt")
+
+
+def test_absolute_path_within_cwd(change_test_dir):
+    """Test getting relative path from an absolute path within the working directory."""
+    abs_path = (Path.cwd() / "test_file.txt").resolve()
+    result = get_relative_path(abs_path)
+    assert result == "test_file.txt"
+
+
+def test_path_outside_cwd(temp_directory):
+    """Test getting path for a location outside the working directory."""
+    # Create a path that's guaranteed to be outside CWD
+    outside_path = temp_directory.parent / "outside_dir" / "file.txt"
+    result = get_relative_path(outside_path)
+    assert result == str(outside_path)
+
+
+def test_nonexistent_path_within_cwd(change_test_dir):
+    """Test getting relative path for a nonexistent file within working directory."""
+    nonexistent = Path("nonexistent.txt")
+    result = get_relative_path(nonexistent)
+    assert result == "nonexistent.txt"
+
+
+def test_path_with_symlink(change_test_dir):
+    """Test getting relative path with a symlink in the path."""
+    # Create a symlink
+    (Path.cwd() / "test_link.txt").symlink_to("test_file.txt")
+    symlink_path = Path("test_link.txt")
+    result = get_relative_path(symlink_path)
+    assert result == "test_file.txt"
+
+
+@pytest.mark.parametrize(
+    "path_str",
+    [
+        ".",
+        "..",
+        "../test",
+        "./test_file.txt",
+    ],
+)
+def test_various_path_formats(change_test_dir, path_str: str):
+    """Test getting relative path with various path format strings."""
+    path = Path(path_str)
+    result = get_relative_path(path)
+    if path_str.startswith("./"):
+        path_str = path_str[2:]
+    assert result == path_str
+
+
+def test_empty_path():
+    """Test getting relative path with an empty path."""
+    empty_path = Path("")
+    result = get_relative_path(empty_path)
+    assert result == "."
+
+
+def test_relative_path_case_sensitivity(change_test_dir):
+    """Test that path case is preserved in the output."""
+    mixed_case = Path("Test_File.txt")
+    result = get_relative_path(mixed_case)
+    assert result == "Test_File.txt"
+
+
+def test_should_ignore():
+    ignore_patterns = EXTENSIONS + FILES + PATTERNS
+
+    assert should_ignore(Path(".gitignore"), ignore_patterns)
+    assert should_ignore(Path("some/path/.gitignore"), ignore_patterns)
+
+    assert should_ignore(Path("image.png"), ignore_patterns)
+    assert should_ignore(Path("deep/path/image.png"), ignore_patterns)
+
+    assert should_ignore(Path(".git/config"), ignore_patterns)
+    assert should_ignore(Path("some/path/.git/config"), ignore_patterns)
+
+    assert not should_ignore(Path("regular.txt"), ignore_patterns)
+    assert not should_ignore(Path("src/main.py"), ignore_patterns)
+
+
+def test_should_ignore_with_ignore_patterns():
+    ignore_patterns = ["*.pyc", "test/*"]
+    assert should_ignore(Path("file.pyc"), ignore_patterns)
+    assert should_ignore(Path("test/file.py"), ignore_patterns)
+    assert not should_ignore(Path("src/file.py"), ignore_patterns)

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "repo-context"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
This pull request includes several changes to the `repo_context` project, focusing on restructuring the codebase, adding new features, and updating dependencies. The most important changes include renaming and refactoring modules, adding a new class for repository structure, and updating the pre-commit configuration.

### Codebase Restructuring:
* Renamed `repo_context/repo_converter.py` to `repo_context/converter.py` and updated all references to the new module name. [[1]](diffhunk://#diff-bf61c0b1e38d48509249dfcfd1a32e98fd17917a38996366b5317b2e10e4acbdL3) [[2]](diffhunk://#diff-4cfa7d00e5da7bf0edb3c9ca627705b68ea03f0fa05e2a24b5b66ddf060ddec3L6-R6) [[3]](diffhunk://#diff-4cfa7d00e5da7bf0edb3c9ca627705b68ea03f0fa05e2a24b5b66ddf060ddec3R63-R81) [[4]](diffhunk://#diff-7b997e5e98f0e4d98b558bcec9a772f82b71ebb00570b8bf39f387a0e13e2cf7L17-R20)
* Moved the `should_ignore` function to a new `repo_context/utils.py` module and removed the corresponding method from `RepoConverter`. [[1]](diffhunk://#diff-bf61c0b1e38d48509249dfcfd1a32e98fd17917a38996366b5317b2e10e4acbdL71-L121) [[2]](diffhunk://#diff-bf61c0b1e38d48509249dfcfd1a32e98fd17917a38996366b5317b2e10e4acbdL185-R157) [[3]](diffhunk://#diff-fda67299d0c4c489a6067f6e32508d839a11552649dd06f21ad9eabab44296dfR1-R60)

### New Features:
* Added a new `RepoStructure` class to generate and handle the directory structure of repositories.
* Integrated the `RepoStructure` class into the `RepoConverter` to include the repository structure in the context conversion process. [[1]](diffhunk://#diff-bf61c0b1e38d48509249dfcfd1a32e98fd17917a38996366b5317b2e10e4acbdR24-R42) [[2]](diffhunk://#diff-bf61c0b1e38d48509249dfcfd1a32e98fd17917a38996366b5317b2e10e4acbdR116-R131)

### Pre-commit Configuration:
* Added a `.pre-commit-config.yaml` file with hooks for end-of-file fixes and code formatting using Ruff.

### Version Update:
* Updated the project version in `pyproject.toml` from `0.2.0` to `0.3.0`.

### Ignore Patterns:
* Updated ignore patterns in `repo_context/ignore.py` to include additional file types and directories. [[1]](diffhunk://#diff-ad04883cf4da6c641c5a61587cb6e2a3030d671bf41206bf8b22c697e50401b5R11-R12) [[2]](diffhunk://#diff-ad04883cf4da6c641c5a61587cb6e2a3030d671bf41206bf8b22c697e50401b5R32-R36) [[3]](diffhunk://#diff-ad04883cf4da6c641c5a61587cb6e2a3030d671bf41206bf8b22c697e50401b5R54)